### PR TITLE
Add instructions for neovim support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,102 @@ To get validation and autocompletion of Spack configuration files, enable an ext
 YAML Language Server Protocol (LSP) in your editor of choice.
 
 * **Visual Studio Code**: Install the [YAML Language Support extension by Red Hat][vsc].
+* **Neovim**: Install [yaml-language-server][yamlls].
+    <details>
+    <summary>0.11.x and newer</summary>
+
+    ```lua
+    --- $XDG_CONFIG_HOME/nvim/lsp/yamlls.lua
+    return {
+      cmd = { "yaml-language-server", "--stdio" },
+      filetypes = { "yaml", "yaml.docker-compose", "yaml.gitlab" },
+      single_file_support = true,
+      settings = {
+        -- https://github.com/redhat-developer/vscode-redhat-telemetry#how-to-disable-telemetry-reporting
+        redhat = { telemetry = { enabled = false } },
+      },
+    }
+
+    --- $XDG_CONFIG_HOME/nvim/init.lua
+    vim.lsp.enable("yamlls")
+    
+    -- Bootstrap lazy.nvim
+    local lazypath = vim.fn.stdpath("data") .. "/lazy/lazy.nvim"
+    if not (vim.uv or vim.loop).fs_stat(lazypath) then
+        local lazyrepo = "https://github.com/folke/lazy.nvim.git"
+        local out = vim.fn.system({ "git", "clone", "--filter=blob:none", "--branch=stable", lazyrepo, lazypath })
+        if vim.v.shell_error ~= 0 then
+            vim.api.nvim_echo({
+                { "Failed to clone lazy.nvim:\n", "ErrorMsg" },
+                { out, "WarningMsg" },
+                { "\nPress any key to exit..." },
+            }, true, {})
+            vim.fn.getchar()
+            os.exit(1)
+        end
+    end
+    vim.opt.rtp:prepend(lazypath)
+
+    vim.g.mapleader = " "
+    vim.g.maplocalleader = "\\"
+
+    -- Setup lazy.nvim
+    require("lazy").setup({
+        spec = {
+            -- For completions.
+            -- See https://cmp.saghen.dev/ for more config options
+            { "saghen/blink.cmp", opts = {} },
+        },
+        checker = { enabled = true },
+    })
+    ```
+    </details>
+    <details>
+    <summary>0.10.x and older</summary>
+
+    ```lua
+    -- Bootstrap lazy.nvim
+    local lazypath = vim.fn.stdpath("data") .. "/lazy/lazy.nvim"
+    if not (vim.uv or vim.loop).fs_stat(lazypath) then
+        local lazyrepo = "https://github.com/folke/lazy.nvim.git"
+        local out = vim.fn.system({ "git", "clone", "--filter=blob:none", "--branch=stable", lazyrepo, lazypath })
+        if vim.v.shell_error ~= 0 then
+            vim.api.nvim_echo({
+                { "Failed to clone lazy.nvim:\n", "ErrorMsg" },
+                { out, "WarningMsg" },
+                { "\nPress any key to exit..." },
+            }, true, {})
+            vim.fn.getchar()
+            os.exit(1)
+        end
+    end
+    vim.opt.rtp:prepend(lazypath)
+
+    vim.g.mapleader = " "
+    vim.g.maplocalleader = "\\"
+
+    -- Setup lazy.nvim
+    require("lazy").setup({
+        spec = {
+            {
+              "neovim/nvim-lspconfig",
+              config = function()
+                local lspconfig = require("lspconfig")
+
+                lspconfig.yamlls.setup({})
+              end,
+            }
+            -- For completions.
+            -- See https://cmp.saghen.dev/ for more config options
+            { "saghen/blink.cmp", opts = {} },
+        },
+        checker = { enabled = true },
+    })
+    ```
+    </details>
 
 [vsc]: https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml
+[yamlls]: https://github.com/redhat-developer/yaml-language-server
 
 Then add the following line at the top of your YAML file:
 


### PR DESCRIPTION
This PR adds minimal setup instructions to enable editor support for the YAML language server in Neovim, specifically for use with Spack.

I've chosen to use the most popular plugin manager and the most widely used completion plugin to ensure users can get things working quickly. While it's possible to configure the LSP without completions, it's not particularly useful without them.

